### PR TITLE
Upgraded RabbitMQ examples NuGet packages to latest stable version

### DIFF
--- a/start/Catalog.API/Catalog.API.csproj
+++ b/start/Catalog.API/Catalog.API.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="8.0.0-preview.3.24105.21" />
+    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="8.1.0" />
   </ItemGroup>
 
 </Project>

--- a/start/Catalog.API/Catalog.API.csproj
+++ b/start/Catalog.API/Catalog.API.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="8.1.0" />
+    <PackageReference Include="Aspire.StackExchange.Redis.DistributedCaching" Version="8.2.0" />
   </ItemGroup>
 
 </Project>

--- a/start/Catalog.Data.Manager/Catalog.Data.Manager.csproj
+++ b/start/Catalog.Data.Manager/Catalog.Data.Manager.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.3.24105.21" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.1">
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/start/Catalog.Data.Manager/Catalog.Data.Manager.csproj
+++ b/start/Catalog.Data.Manager/Catalog.Data.Manager.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.1.0" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/start/Catalog.Data/Catalog.Data.csproj
+++ b/start/Catalog.Data/Catalog.Data.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.1.0" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.2.0" />
   </ItemGroup>
 
 </Project>

--- a/start/Catalog.Data/Catalog.Data.csproj
+++ b/start/Catalog.Data/Catalog.Data.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0-preview.3.24105.21" />
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.1.0" />
   </ItemGroup>
 
 </Project>

--- a/start/WebApp/WebApp.csproj
+++ b/start/WebApp/WebApp.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="8.1.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.1.0" />
+    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="8.2.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/start/WebApp/WebApp.csproj
+++ b/start/WebApp/WebApp.csproj
@@ -13,8 +13,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="8.0.0-preview.3.24105.21" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.0.0-preview.3.24105.21" />
+    <PackageReference Include="Aspire.StackExchange.Redis.OutputCaching" Version="8.1.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/start/eShop.AppHost/KeycloakResource.cs
+++ b/start/eShop.AppHost/KeycloakResource.cs
@@ -1,4 +1,5 @@
-﻿using Aspire.Hosting.Publishing;
+﻿using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.Publishing;
 
 namespace Aspire.Hosting;
 
@@ -17,7 +18,7 @@ internal static class KeycloakHostingExtensions
         return builder
             .AddResource(keycloakContainer)
             .WithAnnotation(new ContainerImageAnnotation { Registry = "quay.io", Image = "keycloak/keycloak", Tag = tag ?? "latest" })
-            .WithHttpEndpoint(hostPort: port, containerPort: DefaultContainerPort)
+            .WithHttpEndpoint(port: port, targetPort: DefaultContainerPort)
             .WithEnvironment("KEYCLOAK_ADMIN", "admin")
             .WithEnvironment("KEYCLOAK_ADMIN_PASSWORD", "admin")
             .WithArgs("start-dev")
@@ -27,8 +28,8 @@ internal static class KeycloakHostingExtensions
     public static IResourceBuilder<KeycloakContainerResource> ImportRealms(this IResourceBuilder<KeycloakContainerResource> builder, string source)
     {
         builder
-            .WithVolumeMount(source, "/opt/keycloak/data/import", VolumeMountType.Bind)
-            .WithAnnotation(new ExecutableArgsCallbackAnnotation(args =>
+            .WithBindMount(source, "/opt/keycloak/data/import")
+            .WithAnnotation(new CommandLineArgsCallbackAnnotation(args =>
             {
                 args.Clear();
                 args.Add("start-dev");
@@ -44,16 +45,16 @@ internal static class KeycloakHostingExtensions
 
         foreach (var annotation in resource.Annotations)
         {
-            if (annotation is not ExecutableArgsCallbackAnnotation)
+            if (annotation is not CommandLineArgsCallbackAnnotation)
             {
                 manifestResource.Annotations.Add(annotation);
             }
         }
 
         // Set the container entry point to 'start' instead of 'start-dev'
-        manifestResource.Annotations.Add(new ExecutableArgsCallbackAnnotation(args => args.Add("start")));
+        manifestResource.Annotations.Add(new CommandLineArgsCallbackAnnotation(args => args.Add("start")));
 
-        context.WriteContainer(resource);
+        context.WriteContainerAsync(resource);
     }
 }
 

--- a/start/eShop.AppHost/Program.cs
+++ b/start/eShop.AppHost/Program.cs
@@ -30,6 +30,6 @@ builder.AddProject<WebApp>("webapp")
     .WithReference(redis);
 
 // Inject assigned URLs for Catalog API
-catalogApi.WithEnvironment("CatalogOptions__PicBaseAddress", () => catalogApi.GetEndpoint("http").UriString);
+catalogApi.WithEnvironment("CatalogOptions__PicBaseAddress", () => catalogApi.GetEndpoint("http").Url);
 
 builder.Build().Run();

--- a/start/eShop.AppHost/Properties/launchSettings.json
+++ b/start/eShop.AppHost/Properties/launchSettings.json
@@ -8,7 +8,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_LAUNCH_PROFILE": "http",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16119"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:16119",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22000"
       },
       "dotnetRunMessages": true,
       "applicationUrl": "http://localhost:18848"
@@ -21,7 +22,8 @@
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_LAUNCH_PROFILE": "https",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:18076"
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:18076",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22000"
       },
       "dotnetRunMessages": true,
       "applicationUrl": "https://localhost:19888"

--- a/start/eShop.AppHost/eShop.AppHost.csproj
+++ b/start/eShop.AppHost/eShop.AppHost.csproj
@@ -11,7 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting" Version="8.0.0-preview.3.24105.21" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.1.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.1.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/start/eShop.AppHost/eShop.AppHost.csproj
+++ b/start/eShop.AppHost/eShop.AppHost.csproj
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.1.0" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.1.0" />
-    <PackageReference Include="Aspire.Hosting.Redis" Version="8.1.0" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="8.2.0" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="8.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/start/eShop.ServiceDefaults/HostingExtensions.cs
+++ b/start/eShop.ServiceDefaults/HostingExtensions.cs
@@ -25,7 +25,7 @@ public static partial class HostingExtensions
             http.AddStandardResilienceHandler();
 
             // Turn on service discovery by default
-            http.UseServiceDiscovery();
+            http.AddServiceDiscovery();
         });
 
         return builder;

--- a/start/eShop.ServiceDefaults/eShop.ServiceDefaults.csproj
+++ b/start/eShop.ServiceDefaults/eShop.ServiceDefaults.csproj
@@ -13,15 +13,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.1.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.0.0-preview.3.24105.21" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.8.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.GrpcNetClient" Version="1.6.0-beta.3" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
   </ItemGroup>
 </Project>

--- a/start/eShop.ServiceDefaults/eShop.ServiceDefaults.csproj
+++ b/start/eShop.ServiceDefaults/eShop.ServiceDefaults.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.8.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.1.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="8.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />


### PR DESCRIPTION
Updated the NuGet packages to the latest versions to resolve pull issues for  Aspire.Hosting.RabbitMQ  preventing successful builds. The previous versions were incompatible, preventing successful pulling of  Aspire.Hosting.RabbitMQ.